### PR TITLE
feat: 改进4K放大重试逻辑和日志大字段截断

### DIFF
--- a/config/setting.toml
+++ b/config/setting.toml
@@ -12,7 +12,7 @@ max_poll_attempts = 200
 
 [server]
 host = "0.0.0.0"
-port = 18282
+port = 8000
 
 [debug]
 enabled = false


### PR DESCRIPTION
- 4K放大失败时使用通用重试逻辑，支持403、reCAPTCHA、超时等多种错误类型
- 日志记录时对 encodedImage 等大字段进行截断处理，避免4K base64数据撑爆日志