### PR TITLE
fix: 修复单帧图生视频 model_key 转换逻辑

### DIFF
--- a/src/services/generation_handler.py
+++ b/src/services/generation_handler.py
@@ -1121,10 +1121,12 @@ class GenerationHandler:
                         user_paygate_tier=token.user_paygate_tier or "PAYGATE_TIER_ONE"
                     )
                 else:
-                    # 只有首帧 - 需要将 model_key 中的 _fl_ 替换为 _
-                    # 例如: veo_3_1_i2v_s_fast_fl_ultra_relaxed -> veo_3_1_i2v_s_fast_ultra_relaxed
-                    #       veo_3_1_i2v_s_fast_portrait_fl_ultra_relaxed -> veo_3_1_i2v_s_fast_portrait_ultra_relaxed
+                    # 只有首帧 - 需要去掉 model_key 中的 _fl
+                    # 情况1: _fl_ 在中间 (如 veo_3_1_i2v_s_fast_fl_ultra_relaxed -> veo_3_1_i2v_s_fast_ultra_relaxed)
+                    # 情况2: _fl 在结尾 (如 veo_3_1_i2v_s_fast_ultra_fl -> veo_3_1_i2v_s_fast_ultra)
                     actual_model_key = model_config["model_key"].replace("_fl_", "_")
+                    if actual_model_key.endswith("_fl"):
+                        actual_model_key = actual_model_key[:-3]
                     debug_logger.log_info(f"[I2V] 单帧模式，model_key: {model_config['model_key']} -> {actual_model_key}")
                     result = await self.flow_client.generate_video_start_image(
                         at=token.at,


### PR DESCRIPTION
修复 I2V 单帧模式下 _fl 后缀去除失败的问题。

原逻辑仅处理 _fl_ 在中间的情况，但实际模型名称 _fl 在结尾：
- veo_3_1_i2v_s_fast_ultra_fl 应转为 veo_3_1_i2v_s_fast_ultra

现在同时处理两种情况：
1. _fl_ 在中间: replace("_fl_", "_")
2. _fl 在结尾: endswith("_fl") 后截取