### PR TITLE
fix: correct directory name typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ docker compose -f docker-compose.headed.yml logs -f
 ```bash
 # 克隆项目
 git clone https://github.com/TheSmallHanCat/flow2api.git
-cd sora2api
+cd flow2api
 
 # 创建虚拟环境
 python -m venv venv


### PR DESCRIPTION
## Summary
- Fixed typo in local deployment instructions: `cd sora2api` → `cd flow2api`
- Line 90 of README.md had the wrong directory name

## Test plan
- [x] Verified the correct directory name matches the repo name

🤖 Generated with [Claude Code](https://claude.com/claude-code)