### PR TITLE
feat: add public health check endpoint

### DIFF
--- a/src/api/admin.py
+++ b/src/api/admin.py
@@ -1102,6 +1102,17 @@ async def logout(token: str = Depends(verify_admin_token)):
     return await admin_logout(token)
 
 
+@router.get("/health")
+async def health_check():
+    """Public health check endpoint - no auth required"""
+    try:
+        stats = await db.get_dashboard_stats()
+        has_active_tokens = stats.get("active_tokens", 0) > 0
+    except Exception:
+        return {"backend_running": True, "has_active_tokens": False}
+    return {"backend_running": True, "has_active_tokens": has_active_tokens}
+
+
 @router.get("/api/stats")
 async def get_stats(token: str = Depends(verify_admin_token)):
     """Get statistics for dashboard"""


### PR DESCRIPTION
## Summary
- Add `GET /health` endpoint (no auth required)
- Returns `backend_running` (bool) and `has_active_tokens` (bool)
- Useful for uptime monitoring tools (UptimeRobot, Kuma, Docker healthcheck, etc.)

## Response example
```json
{
  "backend_running": true,
  "has_active_tokens": true
}
```

## Details
- If DB connection fails, gracefully returns `has_active_tokens: false` instead of crashing
- Reuses existing `get_dashboard_stats()` query
- No breaking changes

## Test plan
- [x] `curl http://localhost:38000/health` returns correct JSON
- [x] Docker build & run successfully