### PR TITLE
fix: avoid impersonation for captcha API JSON requests

### DIFF
--- a/src/api/admin.py
+++ b/src/api/admin.py
@@ -369,11 +369,12 @@ async def _solve_recaptcha_with_api_service(
     create_url = f"{base_url.rstrip('/')}/createTask"
     get_url = f"{base_url.rstrip('/')}/getTaskResult"
 
+    # Do not use curl_cffi impersonation for captcha API JSON endpoints: some ASGI servers
+    # (for example FastAPI/Uvicorn) may receive an empty body and return 422.
     async with AsyncSession() as session:
         create_resp = await session.post(
             create_url,
             json={"clientKey": client_key, "task": task},
-            impersonate="chrome120",
             timeout=30
         )
         create_json = create_resp.json()
@@ -387,7 +388,6 @@ async def _solve_recaptcha_with_api_service(
             poll_resp = await session.post(
                 get_url,
                 json={"clientKey": client_key, "taskId": task_id},
-                impersonate="chrome120",
                 timeout=30
             )
             poll_json = poll_resp.json()

--- a/src/services/flow_client.py
+++ b/src/services/flow_client.py
@@ -2397,6 +2397,8 @@ class FlowClient:
         page_action = action
 
         try:
+            # Do not use curl_cffi impersonation for captcha API JSON endpoints: some ASGI
+            # servers (for example FastAPI/Uvicorn) may receive an empty body and return 422.
             async with AsyncSession() as session:
                 create_url = f"{base_url}/createTask"
                 create_data = {
@@ -2409,7 +2411,7 @@ class FlowClient:
                     }
                 }
 
-                result = await session.post(create_url, json=create_data, impersonate="chrome110")
+                result = await session.post(create_url, json=create_data)
                 result_json = result.json()
                 task_id = result_json.get('taskId')
 
@@ -2426,7 +2428,7 @@ class FlowClient:
                         "clientKey": client_key,
                         "taskId": task_id
                     }
-                    result = await session.post(get_url, json=get_data, impersonate="chrome110")
+                    result = await session.post(get_url, json=get_data)
                     result_json = result.json()
 
                     debug_logger.log_info(f"[reCAPTCHA {method}] polling #{i+1}: {result_json}")


### PR DESCRIPTION
## Summary
- remove `curl_cffi` browser impersonation when calling captcha API JSON endpoints
- keep the existing `AsyncSession` client, but send plain JSON `POST`s for `createTask` / `getTaskResult`
- apply the fix to both admin score-test and runtime `FlowClient` captcha token fetching

## Why
`curl_cffi` with `impersonate="chrome110"/"chrome120"` can cause FastAPI/Uvicorn services to receive an empty request body for JSON `POST`s.

That breaks self-hosted YesCaptcha-compatible services such as OhMyCaptcha with:

```json
{"detail":[{"type":"missing","loc":["body"],"msg":"Field required","input":null}]}
```

## Reproduction
Using `curl_cffi==0.7.3` against a FastAPI/Uvicorn OhMyCaptcha service:
- `AsyncSession().post(..., json=payload)` => works
- `AsyncSession().post(..., json=payload, impersonate="chrome110")` => `422` / missing body
- `AsyncSession().post(..., json=payload, impersonate="chrome120")` => `422` / missing body

## Validation
I validated the patched image locally against a live OhMyCaptcha instance:
- `src.api.admin._solve_recaptcha_with_api_service(...)` returned a token successfully
- `FlowClient._get_api_captcha_token(...)` returned a token successfully

Both paths now reach `/createTask` and `/getTaskResult` with normal `200` responses instead of `422` missing body.
