### PR TITLE
fix(captcha): personal 模式认证代理透传给 Flow 请求，修复上传/生成 代理认证信息丢失

### DIFF
--- a/src/services/browser_captcha_personal.py
+++ b/src/services/browser_captcha_personal.py
@@ -9287,7 +9287,8 @@ class BrowserCaptchaService:
                             )
                         else:
                             proxy_server_arg = f"--proxy-server={protocol}://{host}:{port}"
-                        self._proxy_url = f"{protocol}://{host}:{port}"
+                        # Flow API 请求(curl_cffi)复用此值，必须带 user:pass，否则认证代理会 407
+                        self._proxy_url = _compose_proxy_url(protocol, host, port, username, password)
                         debug_logger.log_info(f"[BrowserCaptcha] Personal 浏览器代理: {self._proxy_url}")
 
                     browser_args = _build_personal_browser_args(


### PR DESCRIPTION
personal 模式下 _resolve_personal_proxy 解析出带 user:pass 的代理后， self._proxy_url 被存成剥离账密的 {protocol}://{host}:{port}（本意是给 Chrome --proxy-server / 认证扩展用，Chrome 不吃 URL 里的账密）。但该值同时被复用为 Flow API 请求(curl_cffi)的出口代理，导致带认证代理下 /flow/uploadImage 等 请求丢失代理认证信息、上传首尾帧失败、视频无法生成。

改为用 _compose_proxy_url 组装带账密的完整地址存入 self._proxy_url。Chrome 侧 代理认证走扩展/命令行 proxy_server_arg，不依赖该值，打码浏览器不受影响；仅补齐
了 Flow 请求侧的代理认证。