### PR TITLE
docs: 修复 README 中损坏的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,5 +580,5 @@ curl -X POST "http://localhost:8000/v1/chat/completions" \
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=TheSmallHanCat/flow2api&type=date&legend=top-left)](https://www.star-history.com/#TheSmallHanCat/flow2api&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=TheSmallHanCat/flow2api&type=date&legend=top-left)](https://star-history.dera.page/#TheSmallHanCat/flow2api&type=date&legend=top-left)
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已经损坏，无法正常展示项目的星标历史。此 PR 将图表迁移到可用的服务上，使其恢复正常显示。